### PR TITLE
Make document iterator thread safe

### DIFF
--- a/src/algorithms/inverted/inverted_index_engine.cpp
+++ b/src/algorithms/inverted/inverted_index_engine.cpp
@@ -9,7 +9,8 @@
 
 #include "../../tokenizer/stemmingtokenizer.hpp"
 
-void InvertedIndexEngine::indexDocuments(DocumentIterator doc_it) {
+void InvertedIndexEngine::indexDocuments(std::string &data_path) {
+  DocumentIterator doc_it(data_path);
   do {
     auto doc = *doc_it;
     auto begin = doc->getData();

--- a/src/algorithms/inverted/inverted_index_engine.cpp
+++ b/src/algorithms/inverted/inverted_index_engine.cpp
@@ -12,23 +12,24 @@
 
 void InvertedIndexEngine::indexDocuments(std::string &data_path) {
   DocumentIterator doc_it(data_path);
-  do {
-    auto doc = *doc_it;
-    auto begin = doc->getData();
-    auto end = begin + doc->getSize();
+  std::vector<Document> current_batch = doc_it.next();
+  while (!current_batch.empty()) {
+    for (Document &doc : current_batch) {
+      auto begin = doc.getData();
 
-    tokenizer::StemmingTokenizer tokenizer(begin, doc->getSize());
+      tokenizer::StemmingTokenizer tokenizer(begin, doc.getSize());
 
-    for (auto token = tokenizer.nextToken(false); !token.empty();
-         token = tokenizer.nextToken(false)) {
-      // increment the number of times a token appeared in that document
-      term_frequency_per_document_[token][doc->getId()]++;
-      // increase the total number of terms in doc d
-      tokens_per_document_[doc->getId()]++;
+      for (auto token = tokenizer.nextToken(false); !token.empty();
+           token = tokenizer.nextToken(false)) {
+        // increment the number of times a token appeared in that document
+        term_frequency_per_document_[token][doc.getId()]++;
+        // increase the total number of terms in doc d
+        tokens_per_document_[doc.getId()]++;
+      }
     }
 
-    ++doc_it;
-  } while (doc_it.hasNext());
+    current_batch = doc_it.next();
+  }
 }
 
 double InvertedIndexEngine::docScoreForToken(uint32_t docId, const std::string &token) {

--- a/src/algorithms/inverted/inverted_index_engine.cpp
+++ b/src/algorithms/inverted/inverted_index_engine.cpp
@@ -7,6 +7,7 @@
 #include <numeric>
 #include <string>
 
+#include "../../documents/document_iterator.hpp"
 #include "../../tokenizer/stemmingtokenizer.hpp"
 
 void InvertedIndexEngine::indexDocuments(std::string &data_path) {

--- a/src/algorithms/inverted/inverted_index_engine.hpp
+++ b/src/algorithms/inverted/inverted_index_engine.hpp
@@ -11,7 +11,7 @@ struct Token;
 
 class InvertedIndexEngine : public FullTextSearchEngine {
  public:
-  void indexDocuments(DocumentIterator it) override;
+  void indexDocuments(std::string &data_path) override;
 
   std::vector<std::pair<DocumentID, double>> search(const std::string &query,
                                                     const scoring::ScoringFunction &score_func,

--- a/src/algorithms/trigram/trigram_index_engine.cpp
+++ b/src/algorithms/trigram/trigram_index_engine.cpp
@@ -5,7 +5,7 @@
 #include <stdexcept>
 #include <string>
 
-void TrigramIndexEngine::indexDocuments(DocumentIterator it) {
+void TrigramIndexEngine::indexDocuments(std::string &data_path) {
   throw std::runtime_error("indexDocuments method is not yet implemented.");
 }
 

--- a/src/algorithms/trigram/trigram_index_engine.hpp
+++ b/src/algorithms/trigram/trigram_index_engine.hpp
@@ -9,7 +9,7 @@
 
 class TrigramIndexEngine : public FullTextSearchEngine {
  public:
-  void indexDocuments(DocumentIterator it) override;
+  void indexDocuments(std::string &data_path) override;
 
   std::vector<std::pair<DocumentID, double>> search(const std::string &query,
                                                     const scoring::ScoringFunction &score_func,

--- a/src/algorithms/vsm/vector_space_model_engine.cpp
+++ b/src/algorithms/vsm/vector_space_model_engine.cpp
@@ -5,7 +5,7 @@
 #include <stdexcept>
 #include <string>
 
-void VectorSpaceModelEngine::indexDocuments(DocumentIterator it) {
+void VectorSpaceModelEngine::indexDocuments(std::string &data_path) {
   throw std::runtime_error("indexDocuments method is not yet implemented.");
 }
 

--- a/src/algorithms/vsm/vector_space_model_engine.hpp
+++ b/src/algorithms/vsm/vector_space_model_engine.hpp
@@ -9,7 +9,7 @@
 
 class VectorSpaceModelEngine : public FullTextSearchEngine {
  public:
-  void indexDocuments(DocumentIterator it) override;
+  void indexDocuments(std::string &data_path) override;
 
   std::vector<std::pair<DocumentID, double>> search(const std::string &query,
                                                     const scoring::ScoringFunction &score_func,

--- a/src/documents/document.hpp
+++ b/src/documents/document.hpp
@@ -12,10 +12,29 @@
  */
 class Document {
  public:
+  /// Default constructor.
+  Document() : id(0), data(nullptr), size(0), arrow_buf(nullptr) {}
   /// Constructor.
-  Document(uint32_t id, const char *data, size_t size,
-           const std::shared_ptr<arrow::Buffer> &arrow_buf)
-      : id(id), data(data), size(size), arrow_buf(arrow_buf) {};
+  Document(uint32_t id, const char *data, size_t size, std::shared_ptr<arrow::Buffer> arrow_buf)
+      : id(id), data(data), size(size), arrow_buf(std::move(arrow_buf)) {};
+  /// Move constructor.
+  Document(Document &&other) noexcept
+      : id(other.id), data(other.data), size(other.size), arrow_buf(std::move(other.arrow_buf)) {}
+  /// Move assigment.
+  Document &operator=(Document &&other) noexcept {
+    if (this != &other) {
+      id = other.id;
+      data = other.data;
+      size = other.size;
+      arrow_buf = std::move(other.arrow_buf);
+    }
+    return *this;
+  }
+  /// Copy Constructor.
+  Document(const Document &) = delete;
+  /// Copy assigment.
+  Document &operator=(const Document &) = delete;
+
   /// Get the document's ID.
   [[nodiscard]] uint32_t getId() const { return id; }
   /// Get a pointer to the document's data.
@@ -29,10 +48,10 @@ class Document {
   /// A pointer to the document's data.
   const char *data;
   /// The document's size in bytes.
-  const size_t size;
+  size_t size;
   /// A pointer to the document's arrow buffer.
   /// Required to keep the data pointer valid.
-  const std::shared_ptr<arrow::Buffer> &arrow_buf;
+  std::shared_ptr<arrow::Buffer> arrow_buf;
 };
 
 #endif  // DOCUMENT_HPP

--- a/src/documents/document_iterator.cpp
+++ b/src/documents/document_iterator.cpp
@@ -2,22 +2,23 @@
 
 #include <arrow/array.h>
 #include <arrow/memory_pool.h>
-#include <arrow/record_batch.h>
+#include <arrow/table.h>
 
-DocumentIterator::DocumentIterator(const std::string &folder_path) {
+#include <iostream>
+#include <thread>
+
+DocumentIterator::DocumentIterator(const std::string &folder_path)
+    : num_row_groups(0), batch_size(128), row_batch_index(0), row_group_index(0) {
   // Enqueue all Parquet files from the folder
   for (const auto &entry : fs::directory_iterator(folder_path)) {
     if (entry.is_regular_file() && entry.path().extension() == ".parquet") {
       file_queue.push(entry.path().string());
     }
   }
-
-  loadNextFile();
 }
 
 void DocumentIterator::loadNextFile() {
   if (file_queue.empty()) {
-    batch_reader.reset();
     arrow_reader.reset();
     return;
   }
@@ -32,69 +33,47 @@ void DocumentIterator::loadNextFile() {
   PARQUET_THROW_NOT_OK(
       parquet::arrow::OpenFile(infile, arrow::default_memory_pool(), &arrow_reader));
 
-  PARQUET_THROW_NOT_OK(
-      arrow_reader->GetRecordBatchReader({0}, &batch_reader));  // Read only column 0
+  num_row_groups = static_cast<uint32_t>(arrow_reader->num_row_groups());
+  row_group_index = 0;
 
-  current_row_index = 0;
-  total_rows_in_batch = 0;
-
-  if (!loadNextBatch()) {
-    loadNextFile();
-  }
+  loadNextRowGroup();
 }
 
-bool DocumentIterator::loadNextBatch() {
-  if (!batch_reader) {
-    return false;
-  }
+bool DocumentIterator::loadNextRowGroup() {
+  if (row_group_index == num_row_groups) return false;
 
-  PARQUET_THROW_NOT_OK(batch_reader->ReadNext(&current_batch));
+  std::shared_ptr<arrow::Table> table;
+  PARQUET_THROW_NOT_OK(arrow_reader->ReadRowGroup(row_group_index, &table));
+  PARQUET_ASSIGN_OR_THROW(table, table->CombineChunks());
 
-  if (!current_batch || current_batch->num_rows() == 0) {
-    return false;
-  }
+  std::shared_ptr<arrow::ChunkedArray> data_column = table->column(0);
+  std::shared_ptr<arrow::ChunkedArray> id_column = table->column(1);
 
-  data_array = std::dynamic_pointer_cast<arrow::BinaryArray>(current_batch->column(0));
-  doc_id_array = std::dynamic_pointer_cast<arrow::UInt32Array>(current_batch->column(1));
-  if (!data_array) {
+  content_array = std::dynamic_pointer_cast<arrow::BinaryArray>(data_column->chunk(0));
+  doc_id_array = std::dynamic_pointer_cast<arrow::UInt32Array>(id_column->chunk(0));
+
+  if (!content_array) {
     throw std::runtime_error("Column 0 is not of type BinaryArray");
   }
 
-  total_rows_in_batch = current_batch->num_rows();
-  current_row_index = 0;
+  ++row_group_index;
+  row_batch_index = 0;
 
   return true;
 }
 
-bool DocumentIterator::hasNext() {
-  while (true) {
-    if (!current_batch) {
-      return false;
-    }
-
-    if (current_row_index < total_rows_in_batch) {
-      return true;
-    } else if (loadNextBatch()) {
-      continue;
-    } else {
-      loadNextFile();
-      if (!current_batch) {
-        return false;
-      }
-    }
-  }
-}
+bool DocumentIterator::hasNext() { return true; }
 
 std::shared_ptr<Document> DocumentIterator::operator*() {
   int32_t length = 0;
 
-  const uint8_t *value = data_array->GetValue(current_row_index, &length);
+  const uint8_t *value = content_array->GetValue(0, &length);
 
-  std::shared_ptr<arrow::Buffer> buffer = data_array->value_data();
+  std::shared_ptr<arrow::Buffer> buffer = content_array->value_data();
 
   auto *data_ptr = reinterpret_cast<const char *>(value);
 
-  uint32_t doc_id = doc_id_array->GetView(current_row_index);
+  uint32_t doc_id = doc_id_array->GetView(0);
 
   return std::make_shared<Document>(doc_id, data_ptr, length, buffer);
 }
@@ -103,7 +82,54 @@ void DocumentIterator::operator++() {
   if (!hasNext()) {
     throw std::out_of_range("No more documents available");
   }
-  current_row_index++;
 }
 
 void DocumentIterator::operator++(int) { ++(*this); }
+
+void DocumentIterator::readBatch(size_t start, size_t end, std::vector<Document> &docs) {
+  for (size_t current = start; current < end; ++current) {
+    // Read row
+    int32_t length = 0;
+
+    const uint8_t *value = content_array->GetValue(current, &length);
+    std::shared_ptr<arrow::Buffer> buffer = content_array->value_data();
+    auto *data_ptr = reinterpret_cast<const char *>(value);
+
+    uint32_t doc_id = doc_id_array->GetView(current);
+
+    // Insert into document vector
+    docs[current & (batch_size - 1)] = Document(doc_id, data_ptr, length, buffer);
+  }
+}
+
+std::vector<Document> DocumentIterator::next() {
+  std::unique_lock lck(global_lock);
+
+  // current file exhausted
+  if (row_group_index == num_row_groups) {
+    loadNextFile();
+  }
+
+  // current row group exhausted
+  if (row_batch_index * batch_size >= content_array->length()) {
+    if (!loadNextRowGroup()) {
+      return {};
+    }
+  }
+
+  // read the next batch
+
+  // for the last batch, there might not be batch_size elements left
+  uint32_t real_batch_size = std::min(
+      batch_size, static_cast<uint32_t>(content_array->length() - batch_size * row_batch_index));
+
+  std::vector<Document> docs(real_batch_size);
+  readBatch(batch_size * row_batch_index,
+            std::min(static_cast<size_t>(batch_size * (row_batch_index + 1)),
+                     static_cast<size_t>(content_array->length())),
+            docs);
+
+  ++row_batch_index;
+
+  return docs;
+}

--- a/src/documents/document_iterator.cpp
+++ b/src/documents/document_iterator.cpp
@@ -7,8 +7,8 @@
 #include <iostream>
 #include <thread>
 
-DocumentIterator::DocumentIterator(const std::string &folder_path)
-    : num_row_groups(0), batch_size(128), row_batch_index(0), row_group_index(0) {
+DocumentIterator::DocumentIterator(const std::string &folder_path, uint32_t batch_size)
+    : num_row_groups(0), row_group_index(0), batch_size(batch_size), row_batch_index(0) {
   // Enqueue all Parquet files from the folder
   for (const auto &entry : fs::directory_iterator(folder_path)) {
     if (entry.is_regular_file() && entry.path().extension() == ".parquet") {

--- a/src/documents/document_iterator.cpp
+++ b/src/documents/document_iterator.cpp
@@ -62,30 +62,6 @@ bool DocumentIterator::loadNextRowGroup() {
   return true;
 }
 
-bool DocumentIterator::hasNext() { return true; }
-
-std::shared_ptr<Document> DocumentIterator::operator*() {
-  int32_t length = 0;
-
-  const uint8_t *value = content_array->GetValue(0, &length);
-
-  std::shared_ptr<arrow::Buffer> buffer = content_array->value_data();
-
-  auto *data_ptr = reinterpret_cast<const char *>(value);
-
-  uint32_t doc_id = doc_id_array->GetView(0);
-
-  return std::make_shared<Document>(doc_id, data_ptr, length, buffer);
-}
-
-void DocumentIterator::operator++() {
-  if (!hasNext()) {
-    throw std::out_of_range("No more documents available");
-  }
-}
-
-void DocumentIterator::operator++(int) { ++(*this); }
-
 void DocumentIterator::readBatch(size_t start, size_t end, std::vector<Document> &docs) {
   for (size_t current = start; current < end; ++current) {
     // Read row

--- a/src/documents/document_iterator.hpp
+++ b/src/documents/document_iterator.hpp
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <memory>
+#include <mutex>
 #include <queue>
 #include <string>
 
@@ -21,36 +22,50 @@ class DocumentIterator {
  public:
   /// Constructor.
   explicit DocumentIterator(const std::string &folder_path);
+
   /// Prefix increment operator.
   void operator++();
   /// Postfix increment operator.
   void operator++(int);
   /// Dereference operator.
   std::shared_ptr<Document> operator*();
-  /// Whether there is another document.
+
+  /// Whether there is another batch of documents.
   bool hasNext();
+  /// @brief Produces the next batch of documents.
+  /// @return The produced batch of documents.
+  /// Empty if there are no documents left.
+  std::vector<Document> next();
 
  private:
   /// Load the next file in the given directory.
   void loadNextFile();
-  /// Load the next batch of rows.
-  bool loadNextBatch();
+  /// Load the next row group.
+  /// @return False if there is no row group left.
+  bool loadNextRowGroup();
+  /// Read raw data within provided borders into the document vector.
+  void readBatch(size_t start, size_t num_rows, std::vector<Document> &docs);
 
   /// A queue of parquet files contained in the specified directory.
   std::queue<std::string> file_queue;
   /// An abstraction used to read parquet files into arrow batches.
   std::unique_ptr<parquet::arrow::FileReader> arrow_reader;
-  /// An abstraction used to read rows into arrow batches.
-  std::shared_ptr<arrow::RecordBatchReader> batch_reader;
-  /// The current batch the iterator is working on.
-  std::shared_ptr<arrow::RecordBatch> current_batch;
-  /// The current batch's raw data.
-  std::shared_ptr<arrow::BinaryArray> data_array;
+  /// The current batch's raw content data.
+  std::shared_ptr<arrow::BinaryArray> content_array;
+  /// The current batch's raw document ID data.
   std::shared_ptr<arrow::UInt32Array> doc_id_array;
-  /// The current row of the iterator's current batch.
-  int64_t current_row_index = 0;
-  /// The total number of rows in the iterator's current batch.
-  int64_t total_rows_in_batch = 0;
+
+  /// The number of row groups in current file.
+  uint32_t num_row_groups;
+  /// The current row group.
+  uint32_t row_group_index;
+  /// The number of documents in a single batch.
+  uint32_t batch_size;
+  /// The index of the current row batch.
+  uint32_t row_batch_index;
+
+  /// A global lock on the next function to sychronize multiple threads.
+  std::mutex global_lock;
 };
 
 #endif  // DOCUMENT_ITERATOR_HPP

--- a/src/documents/document_iterator.hpp
+++ b/src/documents/document_iterator.hpp
@@ -23,15 +23,6 @@ class DocumentIterator {
   /// Constructor.
   explicit DocumentIterator(const std::string &folder_path, uint32_t batch_size = 128);
 
-  /// Prefix increment operator.
-  void operator++();
-  /// Postfix increment operator.
-  void operator++(int);
-  /// Dereference operator.
-  std::shared_ptr<Document> operator*();
-
-  /// Whether there is another batch of documents.
-  bool hasNext();
   /// @brief Produces the next batch of documents.
   /// @return The produced batch of documents.
   /// Empty if there are no documents left.

--- a/src/documents/document_iterator.hpp
+++ b/src/documents/document_iterator.hpp
@@ -21,7 +21,7 @@ namespace fs = std::filesystem;
 class DocumentIterator {
  public:
   /// Constructor.
-  explicit DocumentIterator(const std::string &folder_path);
+  explicit DocumentIterator(const std::string &folder_path, uint32_t batch_size = 128);
 
   /// Prefix increment operator.
   void operator++();

--- a/src/fts_engine.hpp
+++ b/src/fts_engine.hpp
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "documents/document.hpp"
-#include "documents/document_iterator.hpp"
 #include "scoring/scoring_function.hpp"
 
 using DocumentID = uint32_t;

--- a/src/fts_engine.hpp
+++ b/src/fts_engine.hpp
@@ -33,7 +33,7 @@ class FullTextSearchEngine {
    *
    * @param it DocumentIterator providing access to the documents to be indexed.
    */
-  virtual void indexDocuments(DocumentIterator it) = 0;
+  virtual void indexDocuments(std::string &data_path) = 0;
   /**
    * @brief Searches for documents matching the given query.
    *

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,9 +33,6 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  auto directory_path = result["data"].as<std::string>();
-  DocumentIterator it(directory_path);
-
   auto algorithm_choice = result["algorithm"].as<std::string>();
   std::unique_ptr<FullTextSearchEngine> engine;
   if (algorithm_choice == "vsm") {
@@ -50,7 +47,8 @@ int main(int argc, char** argv) {
   }
 
   // Build the index
-  engine->indexDocuments(std::move(it));
+  auto directory_path = result["data"].as<std::string>();
+  engine->indexDocuments(directory_path);
 
   // Scoring
   std::unique_ptr<scoring::ScoringFunction> score_func;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,7 +7,6 @@
 #include "algorithms/inverted/inverted_index_engine.hpp"
 #include "algorithms/trigram/trigram_index_engine.hpp"
 #include "algorithms/vsm/vector_space_model_engine.hpp"
-#include "documents/document_iterator.hpp"
 #include "fts_engine.hpp"
 #include "scoring/bm25.hpp"
 #include "scoring/scoring_function.hpp"


### PR DESCRIPTION
# Make document iterator thread safe

This is a basic, not very sophisticated, approach to make the `DocumentIterator` thread-safe and thus allowing to build the indexes using multiple threads.

## Implementation

The synchronisation works by acquiring a global lock during the call to the `next` function. The `next` function then produces the next batch of rows (batch size is configurable), from which the calling thread can build the index.
To be more precise, the iterator iterates over all **parquet-files** in provided directory. Then, it fetches all **row group**s one by one and splits the row group into individual **row batches** on which the calling threads work.

Also note that I adjusted the interface of the `FTSEngine` such that the `DocumentIterator` is built within the index. The alternative would have been to make the `DocumentIterator` movable, which, for me personally, does not make sense design-wise, since there is no reason to move it after or while being used by an engine. I am open for discussion.

## Caution

The old interface will most likely not work anymore, even single threaded. Thus, @DhiaBou  or @Julian-JP please change your InvertedIndex-implementation accordingly.
Also note that the old interface is only still in the code base to prevent building errors. There is no need to keep it when you adjusted to the new interface.

## Comments

As mentioned, this approach is very basic. Feel free to extend, improve or even change this completely, I am open for discussions!