### PR TITLE
Added footprint_size method

### DIFF
--- a/src/algorithms/inverted/inverted_index_engine.cpp
+++ b/src/algorithms/inverted/inverted_index_engine.cpp
@@ -161,14 +161,27 @@ std::vector<std::pair<DocumentID, double>> InvertedIndexEngine::search(
   return top_documents;
 }
 
-uint64_t InvertedIndexEngine::footprint() {
+uint64_t InvertedIndexEngine::footprint_capacity() {
   using tokens_per_document_type = decltype(tokens_per_document_)::value_type;
   size_t tokens_per_document_footprint =
       tokens_per_document_.capacity() * sizeof(tokens_per_document_type);
 
-  size_t token_frequency_map_footprint = term_frequency_per_document_.footprint();
+  size_t token_frequency_map_footprint = term_frequency_per_document_.footprint_capacity();
   for (auto &[key, value] : term_frequency_per_document_) {
     token_frequency_map_footprint += (value.capacity() * sizeof(std::pair<uint32_t, uint32_t>));
+  }
+  return token_frequency_map_footprint + tokens_per_document_footprint +
+         sizeof(InvertedIndexEngine);
+}
+
+uint64_t InvertedIndexEngine::footprint_size() {
+  using tokens_per_document_type = decltype(tokens_per_document_)::value_type;
+  size_t tokens_per_document_footprint =
+      tokens_per_document_.size() * sizeof(tokens_per_document_type);
+
+  size_t token_frequency_map_footprint = term_frequency_per_document_.footprint_size();
+  for (auto &[key, value] : term_frequency_per_document_) {
+    token_frequency_map_footprint += (value.size() * sizeof(std::pair<uint32_t, uint32_t>));
   }
   return token_frequency_map_footprint + tokens_per_document_footprint +
          sizeof(InvertedIndexEngine);

--- a/src/algorithms/inverted/inverted_index_engine.hpp
+++ b/src/algorithms/inverted/inverted_index_engine.hpp
@@ -20,7 +20,9 @@ class InvertedIndexEngine : public FullTextSearchEngine {
   std::vector<std::pair<DocumentID, double>> search(const std::string &query,
                                                     const scoring::ScoringFunction &score_func,
                                                     uint32_t num_results) override;
-  uint64_t footprint() override;
+  uint64_t footprint_size() override;
+
+  uint64_t footprint_capacity() override;
 
   uint32_t getDocumentCount() override;
 

--- a/src/algorithms/trigram/index/index.hpp
+++ b/src/algorithms/trigram/index/index.hpp
@@ -20,8 +20,10 @@ class Index {
   virtual void store(std::ofstream& file) = 0;
   /// Load the underlying data structure from given data.
   virtual void load(const char* begin, const char* end) = 0;
-  /// Determine the memory footprint of the index in Bytes.
+  /// Determines the allocated memory footprint of the index in Bytes.
   virtual uint64_t footprint_capacity() = 0;
+  /// Determines the used memory footprint of the index in Bytes.
+  virtual uint64_t footprint_size() = 0;
 };
 //---------------------------------------------------------------------------
 template <typename ContainerT, uint8_t Size>

--- a/src/algorithms/trigram/index/index.hpp
+++ b/src/algorithms/trigram/index/index.hpp
@@ -21,7 +21,7 @@ class Index {
   /// Load the underlying data structure from given data.
   virtual void load(const char* begin, const char* end) = 0;
   /// Determine the memory footprint of the index in Bytes.
-  virtual uint64_t footprint() = 0;
+  virtual uint64_t footprint_capacity() = 0;
 };
 //---------------------------------------------------------------------------
 template <typename ContainerT, uint8_t Size>

--- a/src/algorithms/trigram/index/parallel_hash_index.hpp
+++ b/src/algorithms/trigram/index/parallel_hash_index.hpp
@@ -47,11 +47,11 @@ class ParallelHashIndex : public Index<DocFreq, std::vector<DocFreq>, MaxOffset>
     // TODO
   }
   //---------------------------------------------------------------------------
-  uint64_t footprint() override {
+  uint64_t footprint_capacity() override {
     uint64_t size = 0;
 
     // Size known at compile time
-    size += table.footprint();
+    size += table.footprint_capacity();
     // Size known at runtime
     for (auto& [key, value] : table) {
       size += (value.size() * sizeof(DocFreq));

--- a/src/algorithms/trigram/index/parallel_hash_index.hpp
+++ b/src/algorithms/trigram/index/parallel_hash_index.hpp
@@ -54,6 +54,19 @@ class ParallelHashIndex : public Index<DocFreq, std::vector<DocFreq>, MaxOffset>
     size += table.footprint_capacity();
     // Size known at runtime
     for (auto& [key, value] : table) {
+      size += (value.capacity() * sizeof(DocFreq));
+    }
+
+    return size;
+  }
+  //---------------------------------------------------------------------------
+  uint64_t footprint_size() override {
+    uint64_t size = 0;
+
+    // Size known at compile time
+    size += table.footprint_size();
+    // Size known at runtime
+    for (auto& [key, value] : table) {
       size += (value.size() * sizeof(DocFreq));
     }
 
@@ -64,6 +77,7 @@ class ParallelHashIndex : public Index<DocFreq, std::vector<DocFreq>, MaxOffset>
     for (auto& [key, value] : table) {
       if (value.size() > max_occurences) {
         value.clear();
+        value.shrink_to_fit();
       }
     }
   }

--- a/src/algorithms/trigram/trigram_index_engine.cpp
+++ b/src/algorithms/trigram/trigram_index_engine.cpp
@@ -160,7 +160,7 @@ uint64_t TrigramIndexEngine::footprint_capacity() {
   // Metadata
   size += sizeof(doc_count);
   size += sizeof(avg_doc_length);
-  size += sizeof(doc_to_length) + doc_to_length.size() * sizeof(uint32_t);
+  size += sizeof(doc_to_length) + doc_to_length.capacity() * sizeof(uint32_t);
 
   // Index
   size += index.footprint_capacity();
@@ -169,8 +169,17 @@ uint64_t TrigramIndexEngine::footprint_capacity() {
 }
 //---------------------------------------------------------------------------
 uint64_t TrigramIndexEngine::footprint_size() {
-  //TODO
-  return -1;
+  uint64_t size = 0;
+
+  // Metadata
+  size += sizeof(doc_count);
+  size += sizeof(avg_doc_length);
+  size += sizeof(doc_to_length) + doc_to_length.size() * sizeof(uint32_t);
+
+  // Index
+  size += index.footprint_size();
+
+  return size;
 }
 //---------------------------------------------------------------------------
 void TrigramIndexEngine::merge(std::vector<std::unordered_map<DocumentID, uint32_t>>& maps) {

--- a/src/algorithms/trigram/trigram_index_engine.cpp
+++ b/src/algorithms/trigram/trigram_index_engine.cpp
@@ -154,7 +154,7 @@ void TrigramIndexEngine::load(const std::string& path) {
   index.load(it, end);
 }
 //---------------------------------------------------------------------------
-uint64_t TrigramIndexEngine::footprint() {
+uint64_t TrigramIndexEngine::footprint_capacity() {
   uint64_t size = 0;
 
   // Metadata
@@ -163,9 +163,14 @@ uint64_t TrigramIndexEngine::footprint() {
   size += sizeof(doc_to_length) + doc_to_length.size() * sizeof(uint32_t);
 
   // Index
-  size += index.footprint();
+  size += index.footprint_capacity();
 
   return size;
+}
+//---------------------------------------------------------------------------
+uint64_t TrigramIndexEngine::footprint_size() {
+  //TODO
+  return -1;
 }
 //---------------------------------------------------------------------------
 void TrigramIndexEngine::merge(std::vector<std::unordered_map<DocumentID, uint32_t>>& maps) {

--- a/src/algorithms/trigram/trigram_index_engine.hpp
+++ b/src/algorithms/trigram/trigram_index_engine.hpp
@@ -19,9 +19,9 @@ class TrigramIndexEngine : public FullTextSearchEngine {
   void store(const std::string &path);
   /// Load the index from specified location.
   void load(const std::string &path);
-  /// Determines the memory footprint of the engine in bytes.
+  /// Determines the allocated memory footprint of the engine in bytes.
   uint64_t footprint_capacity() override;
-
+  /// Determines the used memory footprint of the engine in bytes.
   uint64_t footprint_size() override;
 
   /// Get the number of documents.

--- a/src/algorithms/trigram/trigram_index_engine.hpp
+++ b/src/algorithms/trigram/trigram_index_engine.hpp
@@ -20,7 +20,9 @@ class TrigramIndexEngine : public FullTextSearchEngine {
   /// Load the index from specified location.
   void load(const std::string &path);
   /// Determines the memory footprint of the engine in bytes.
-  uint64_t footprint() override;
+  uint64_t footprint_capacity() override;
+
+  uint64_t footprint_size() override;
 
   /// Get the number of documents.
   uint32_t getDocumentCount() override;

--- a/src/algorithms/vsm/vector_space_model_engine.cpp
+++ b/src/algorithms/vsm/vector_space_model_engine.cpp
@@ -14,7 +14,12 @@ std::vector<std::pair<DocumentID, double>> VectorSpaceModelEngine::search(
   throw std::runtime_error("search method is not yet implemented.");
 }
 
-uint64_t VectorSpaceModelEngine::footprint() {
+uint64_t VectorSpaceModelEngine::footprint_capacity() {
+  // TODO
+  return 0;
+}
+
+uint64_t VectorSpaceModelEngine::footprint_size() {
   // TODO
   return 0;
 }

--- a/src/algorithms/vsm/vector_space_model_engine.hpp
+++ b/src/algorithms/vsm/vector_space_model_engine.hpp
@@ -15,7 +15,9 @@ class VectorSpaceModelEngine : public FullTextSearchEngine {
                                                     const scoring::ScoringFunction &score_func,
                                                     uint32_t num_results) override;
 
-  uint64_t footprint() override;
+  uint64_t footprint_capacity() override;
+
+  uint64_t footprint_size() override;
 
   uint32_t getDocumentCount() override;
 

--- a/src/data-structures/parallel_hash_table.hpp
+++ b/src/data-structures/parallel_hash_table.hpp
@@ -159,7 +159,7 @@ class ParallelHashTable {
   /// The size of the hash table.
   uint32_t size() { return table.size(); }
   /// The memory footprint of the hash table.
-  uint64_t footprint() {
+  uint64_t footprint_capacity() {
     // Note: This function only includes information on the memory footprint
     // that is known at compile time. Any other dynamically allocated memory
     // by key or value must be determined by the instantiating client.
@@ -170,9 +170,25 @@ class ParallelHashTable {
     // Table
     size += table.size() * sizeof(Bucket);
     for (size_t i = 0; i < table.size(); ++i) {
-      for (const auto& [key, value] : table[i].first) {
-        size += sizeof(key);
-        size += sizeof(value);
+      size += table[i].first.capacity() * (sizeof(Key) + sizeof(Value));
+    }
+
+    return size;
+  }
+
+  uint64_t footprint_size() {
+    // Note: This function only includes information on the memory footprint
+    // that is known at compile time. Any other dynamically allocated memory
+    // by key or value must be determined by the instantiating client.
+    uint64_t size = 0;
+
+    // Metadata
+    size += sizeof(table_mask);
+    // Table
+    for (size_t i = 0; i < table.size(); ++i) {
+      if (table[i].first.size() != 0) {
+        size += sizeof(Bucket);
+        size += table[i].first.size() * (sizeof(Key) + sizeof(Value));
       }
     }
 

--- a/src/fts_engine.hpp
+++ b/src/fts_engine.hpp
@@ -47,11 +47,17 @@ class FullTextSearchEngine {
       const std::string &query, const scoring::ScoringFunction &score_func,
       uint32_t num_results) = 0;
   /**
-   * @brief Determines the engine's memory footprint.
+   * @brief Determines the engine's memory footprint. (Only real needed memory)
+   *
+   * @return The memory footprint in bytes without overallocation.
+   */
+  virtual uint64_t footprint_size() = 0;
+  /**
+   * @brief Determines the engine's memory footprint. (All allocated memory)
    *
    * @return The memory footprint in bytes.
    */
-  virtual uint64_t footprint() = 0;
+  virtual uint64_t footprint_capacity() = 0;
   /**
    * @brief Gets the number of indexed documents.
    *


### PR DESCRIPTION
We now have 2 footprint method the footprint_size and footprint_capacity
footprint_capacity: Measures every memory allocated by the index
footprint_size: Measures only the real needed memory. E.g. if there is an empty bucket in a hashmap the size of the bucket is not part of the footprint_size